### PR TITLE
Khmer splinter state bug fixes

### DIFF
--- a/common/ideas/00_country_ideas_2_CAMBODIA.txt
+++ b/common/ideas/00_country_ideas_2_CAMBODIA.txt
@@ -14,7 +14,7 @@ KHS_ideas = {
 	
 	trigger = {
 		NOT = { tag = KHM }
-		primary_culture = northern_thai
+		primary_culture = khmer
 	}
 	free = yes
 	

--- a/localisation/01_CAMBODIA_powers_and_ideas_l_english.yml
+++ b/localisation/01_CAMBODIA_powers_and_ideas_l_english.yml
@@ -2,26 +2,26 @@
 KHS_ideas:0 "Cambodian Minor Ideas"
 KHS_ideas_desc:0 "The Dark Age of Cambodia is marked by numerous incursion from Siamese and Laotian upstarts, the once-mighty Empire of Angkor retreated and abandon their holding outside their heartland in Mekong Delta and Tonle Sap. Time will tell if they are capable of reclaiming the mantle stays a fragmented princedom."
 
-KHS_ideas_start:0 "Wise Purihota."
-KHS_ideas_bonus:0 "Mantle of Angkor."
+KHS_ideas_start:0 "Wise Purihota"
+KHS_ideas_bonus:0 "Mantle of Angkor"
 
-KHS_survivor_of_siamese_onslaught:0 "Survivor of Siamese Onslaugt."
+KHS_survivor_of_siamese_onslaught:0 "Survivor of Siamese Onslaugt"
 KHS_survivor_of_siamese_onslaught_desc:0 "The Theiving Siamese have taken a lot from us, be it our relic, scripture, land or people. One thing they will never take from us is the indomitable Khmer spirit, we will die defending the land or survive defiantly."
 
-KHS_devoted_theravadin:0 "Devout Theravadin."
+KHS_devoted_theravadin:0 "Devout Theravadin"
 KHS_devoted_theravadin_desc:0 "Buddhism, despite their relatively recent arrival to Kambujadesa, became integral part of our cultural identity. Attaining monkhood is rite of passage for most man who are able to, and our monastery send envoy to far-flung part of the world to gain wisdom."
 
-KHS_home_of_naga:0 "Home of Naga."
+KHS_home_of_naga:0 "Home of Naga"
 KHS_home_of_naga_desc:0 "The Heartland of Angkorean Empire have always been close to the water, be it Tonle Sap or Mekong. We Khmer owe our existence to the union between Preah Thong, wise scholar from Jambudvipa, and Neang Neak, Naga Princess of this land."
 
-KHS_destination_of_merchant_and_mercenary:0 "Destination of Merchant and Mercenary."
+KHS_destination_of_merchant_and_mercenary:0 "Destination of Merchant and Mercenary"
 KHS_destination_of_merchant_and_mercenary_desc:0 "The Turmoil occuring in the land once ruled by Angkor set us as prime destination of foreign mercenary who seek fortune and fame, in the meanwhile, the conflict have not deterred the merchant who seek our wares either."
 
-KHS_resettlement_efforts:0 "Resettlement Efforts."
+KHS_resettlement_efforts:0 "Resettlement Efforts"
 KHS_resettlement_efforts_desc:0 "The Calamity that befallen Angkor of old must not be repeated, we must populate the frontier of our realms with men or left it undefended and open for another invasions."
 
-KHS_restore_the_ruin:0 "Restore the Ruin."
+KHS_restore_the_ruin:0 "Restore the Ruin"
 KHS_restore_the_ruin_desc:0 "Hollow Vihara and Abandoned Wat dotted across the land of Old Angkor, now that we have people and the land, our builder will focus on the restoration of our splendors."
 
-KHS_heir_of_angkor:0 "Heir of Angkor."
+KHS_heir_of_angkor:0 "Heir of Angkor"
 KHS_heir_of_angkor_desc:0 "The Angkor Empire may have been thing of the part, but our rise to power have cemented their legacy firm."


### PR DESCRIPTION
Assigned correct culture group for (northern_thai -> khmer)
- Oudong (OUD)
- Lavek (LVK)
- Chaktomuk (CTK)